### PR TITLE
Fix SonarQube Password

### DIFF
--- a/scripts/runSonarQube.sh
+++ b/scripts/runSonarQube.sh
@@ -20,7 +20,7 @@ sonar_host="http://localhost:$sonar_port"
 sonar_project="benchmark"
 sonar_user="admin"
 sonar_default_password="admin"
-sonar_password="password"
+sonar_password="PasswordWithNumb3rsAndSpecialCharacters!"
 
 echo "Creating temporary SonarQube instance"
 


### PR DESCRIPTION
The latest version of SonarQube requires new passwords to be at least 12 characters with number and special characters
